### PR TITLE
Simplify migration from `postcss-modules` library.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ const css = `
 let exportedTokens = {}
 const styles = postcss([
   CSSModulesSync({
-    getTokens: tokens => exportedTokens = tokens
+    generateScopedName: '[path][local]-[hash:base64:10]',
+    getJSON: tokens => exportedTokens = tokens
   })
 ]).process(css).css
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -24,9 +24,18 @@ var _postcss = require('postcss');
 
 var _postcss2 = _interopRequireDefault(_postcss);
 
+var _genericNames = require('generic-names');
+
+var _genericNames2 = _interopRequireDefault(_genericNames);
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-_postcssModulesScope2.default.generateScopedName = _scopeGenerator2.default;
+function getScopedNameGenerator(opts) {
+  var scopedNameGenerator = opts.generateScopedName || _scopeGenerator2.default;
+
+  if (typeof scopedNameGenerator === 'function') return scopedNameGenerator;
+  return (0, _genericNames2.default)(scopedNameGenerator, { context: process.cwd() });
+}
 
 exports.default = _postcss2.default.plugin('postcss-css-modules', function () {
   var opts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
@@ -34,8 +43,12 @@ exports.default = _postcss2.default.plugin('postcss-css-modules', function () {
   var plugins = [_postcssModulesLocalByDefault2.default, _postcssModulesScope2.default];
   var parser = new _Parser2.default();
 
+  _postcssModulesScope2.default.generateScopedName = getScopedNameGenerator(opts);
+
   return function (css, result) {
     var styles = (0, _postcss2.default)(plugins.concat(parser.plugin)).process(css).css;
-    opts.getTokens(parser.exportTokens);
+    if (opts.getJSON != undefined) {
+      opts.getJSON(parser.exportTokens);
+    }
   };
 });

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "build": "babel ./src --out-dir ./lib"
   },
   "dependencies": {
+    "generic-names": "^1.0.2",
     "icss-replace-symbols": "^1.0.2",
     "postcss": "^5.2.5",
     "postcss-modules-local-by-default": "^1.1.1",

--- a/src/index.js
+++ b/src/index.js
@@ -3,15 +3,25 @@ import scopeGenerator from './scopeGenerator'
 import localByDefault from 'postcss-modules-local-by-default'
 import scope from 'postcss-modules-scope'
 import postcss from 'postcss'
+import genericNames from 'generic-names';
 
-scope.generateScopedName = scopeGenerator
+function getScopedNameGenerator(opts) {
+  const scopedNameGenerator = opts.generateScopedName || scopeGenerator;
+
+  if (typeof scopedNameGenerator === 'function') return scopedNameGenerator;
+  return genericNames(scopedNameGenerator, {context: process.cwd()});
+}
 
 export default postcss.plugin('postcss-css-modules', (opts = {}) => {
-  const plugins = [localByDefault, scope]
-  const parser = new Parser()
-  
+  const plugins = [localByDefault, scope];
+  const parser = new Parser();
+
+  scope.generateScopedName = getScopedNameGenerator(opts);
+
   return (css, result) => {
-    const styles = postcss(plugins.concat(parser.plugin)).process(css).css
-    opts.getTokens(parser.exportTokens)
+    const styles = postcss(plugins.concat(parser.plugin)).process(css).css;
+    if (opts.getJSON != undefined) {
+      opts.getJSON(parser.exportTokens)
+    }
   }
 })


### PR DESCRIPTION
Rename getTokens to getJSON method, to simplify migration from async library.
Add ability to define custom `generateScopedName` function.